### PR TITLE
Fixed 2 unit test failed if use ION/SDP secure buffer

### DIFF
--- a/host/aes_crypto.c
+++ b/host/aes_crypto.c
@@ -208,7 +208,7 @@ TEE_AES_ctr128_encrypt(const unsigned char* in_data,
   CHECK_INVOKE(res, err_origin);
 
 #ifdef SDP_PROTOTYPE
-  ion_map_and_memcpy(out_data + offset - blockOffset, length + blockOffset, secure_fd);
+  ion_map_and_memcpy(out_data + offset, length, secure_fd, blockOffset);
   close(secure_fd);
 #endif
 
@@ -287,7 +287,7 @@ int TEE_copy_secure_memory(const unsigned char* out_data, const unsigned char* i
 
 #ifdef SDP_PROTOTYPE
   /* sdp_protoype test code assumes memory isn't actually secure */
-  ion_map_and_memcpy(out_data + offset, length, secure_fd);
+  ion_map_and_memcpy(out_data + offset, length, secure_fd, 0);
   close(secure_fd);
 #endif
 

--- a/host/clearkey_platform.c
+++ b/host/clearkey_platform.c
@@ -109,7 +109,10 @@ out:
 	return fd;
 }
 
-int ion_map_and_memcpy(unsigned char* out_data, uint32_t length, int secure_fd)
+int ion_map_and_memcpy(unsigned char* out_data,
+                uint32_t length,
+                int secure_fd,
+                uint32_t blockOffset)
 {
   /* To allow prototyping SDP, map the secure buffer
      (it is not actually protected) and copy data into the destination
@@ -140,7 +143,7 @@ int ion_map_and_memcpy(unsigned char* out_data, uint32_t length, int secure_fd)
     goto error2;
   }
 
-  memcpy(out_data, mapped_secure_buf, length);
+  memcpy(out_data, mapped_secure_buf + blockOffset, length);
   munmap(mapped_secure_buf, length);
   close(map_fd);
 

--- a/host/clearkey_platform.h
+++ b/host/clearkey_platform.h
@@ -34,6 +34,6 @@
 int clearkey_plat_get_mem_fd(void *mem_handle);
 #ifdef SDP_PROTOTYPE
 int allocate_ion_buffer(size_t size, int heap_id);
-int ion_map_and_memcpy(unsigned char* out_data, uint32_t length, int secure_fd);
+int ion_map_and_memcpy(unsigned char* out_data, uint32_t length, int secure_fd, uint32_t blockOffset);
 #endif
 #endif


### PR DESCRIPTION
The DecryptsUnalignedMixedSubSamples and DecryptsComplexMixedSubSamples case
both include clear data and encrypted data mixed, the clear data can be move
to the out buffer. when the encrypted data been decrypted, the decrypted data
should skip the blockoffset.